### PR TITLE
Fix RSS feed: correct post URLs and add auto-discovery

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -20,6 +20,9 @@ const { title, description, image = "/placeholder-social.jpg" } = Astro.props;
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
 
+<!-- RSS Feed -->
+<link rel="alternate" type="application/rss+xml" title={title} href={new URL('/rss.xml', Astro.site)} />
+
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
 

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -10,7 +10,7 @@ export async function GET(context) {
 		site: context.site,
 		items: posts.map((post) => ({
 			...post.data,
-			link: `/blog/${post.id.replace(/\.md$/, '')}/`,
+			link: `/${post.id.replace(/\.md$/, '')}/`,
 		})),
 	});
 }


### PR DESCRIPTION
## Problems found

1. **RSS links were broken** -- feed items pointed to `/blog/<slug>/` but posts live at `/<slug>/` (no `/blog/` prefix). All 56 RSS links returned 404.
2. **No RSS auto-discovery** -- browsers and feed readers could not auto-detect the RSS feed because no `<link rel="alternate">` tag was present in the HTML.

## Fixes

- **`src/pages/rss.xml.js`** -- removed `/blog/` prefix from item links
- **`src/components/BaseHead.astro`** -- added `<link rel="alternate" type="application/rss+xml">` to every page

## Verification

- RSS XML now has correct links: `https://jackbravo.github.io/<slug>/`
- All pages include the RSS auto-discovery meta tag