### PR TITLE
fix: Add SEO description to all blog posts

### DIFF
--- a/src/content/blog/anular-el-voto-o-no-anular-el-voto-esa-es-la-cuestion.md
+++ b/src/content/blog/anular-el-voto-o-no-anular-el-voto-esa-es-la-cuestion.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2009-06-08T12:29:53.000Z'
 tags: []
+description: "Reflexión sobre si anular o no el voto en las elecciones mexicanas de 2009, analizando la frustración con la política y la propuesta del movimiento Anúlalos."
 title: Anular el voto, o no anular el voto, esa es la cuestión
 ---
 

--- a/src/content/blog/backups-de-mysql-con-git.md
+++ b/src/content/blog/backups-de-mysql-con-git.md
@@ -5,6 +5,7 @@ pubDate: '2008-08-05T16:26:48.000Z'
 tags:
 - git
 - mysql
+description: "Cómo hacer backups de bases de datos MySQL utilizando git como sistema de control de versiones, aprovechando la opción --tab de mysqldump para rastrear cambios históricos."
 title: Backups de MySQL con git
 ---
 

--- a/src/content/blog/capitalizar-la-primer-letra-de-una-columna-en-mysql.md
+++ b/src/content/blog/capitalizar-la-primer-letra-de-una-columna-en-mysql.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2011-01-17T18:35:38.000Z'
 tags:
 - mysql
+description: "Sentencia SQL para capitalizar la primera letra de una columna en MySQL usando CONCAT, UPPER, LEFT y MID."
 title: Capitalizar la primer letra de una columna en MySQL
 ---
 

--- a/src/content/blog/como-escribir-un-articulo-blog-ensayo.md
+++ b/src/content/blog/como-escribir-un-articulo-blog-ensayo.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2011-02-02T15:58:52.000Z'
 tags:
 - blogs
+description: "Notas del curso 'Start Writing Essays' del Open University sobre cómo escribir un ensayo: investigación, estructura, redacción y revisión."
 title: ¿Cómo escribir un artículo / blog / ensayo?
 ---
 

--- a/src/content/blog/como-explicar-la-recursion.md
+++ b/src/content/blog/como-explicar-la-recursion.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2008-09-19T17:59:04.000Z'
 tags:
 - programacion
+description: "Una explicación sencilla e intuitiva del concepto de recursión en programación, usando una analogía de historias anidadas."
 title: ¿Cómo explicar la recursión?
 ---
 

--- a/src/content/blog/compilando-git-en-ubuntu-710.md
+++ b/src/content/blog/compilando-git-en-ubuntu-710.md
@@ -6,6 +6,7 @@ tags:
 - git
 - linux
 - ubuntu
+description: "Guía para compilar git desde el código fuente en Ubuntu 7.10 e instalar la versión más reciente con soporte para submódulos."
 title: Compilando git en ubuntu 7.10
 ---
 

--- a/src/content/blog/crear-un-calendario-de-grupo-con-drupal.md
+++ b/src/content/blog/crear-un-calendario-de-grupo-con-drupal.md
@@ -5,6 +5,7 @@ pubDate: '2008-09-10T20:03:59.000Z'
 tags:
 - drupal
 - views
+description: "Tutorial para crear un calendario de grupo en Drupal usando organic groups, CCK, date, views y calendar para mostrar actividades por comunidad."
 title: Crear un calendario de grupo con drupal
 ---
 

--- a/src/content/blog/crear-un-nuevo-proyecto-compartido-en-git.md
+++ b/src/content/blog/crear-un-nuevo-proyecto-compartido-en-git.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2008-12-10T02:23:31.000Z'
 tags:
 - git
+description: "Cómo crear un repositorio git compartido en un servidor público usando git --bare init en lugar del método tradicional de clonación."
 title: Crear un nuevo proyecto compartido en git
 ---
 

--- a/src/content/blog/cvs-desde-git-y-como-mantenerlos-sincronizados.md
+++ b/src/content/blog/cvs-desde-git-y-como-mantenerlos-sincronizados.md
@@ -5,6 +5,7 @@ pubDate: '2008-07-24T15:27:50.000Z'
 tags:
 - git
 - drupal
+description: "Cómo usar git-cvsimport para rastrear módulos de Drupal que están en CVS y mantenerlos sincronizados con git."
 title: CVS desde git, y como mantenerlos sincronizados
 ---
 

--- a/src/content/blog/debuguear-php-con-emacs-xdebug-y-geben.md
+++ b/src/content/blog/debuguear-php-con-emacs-xdebug-y-geben.md
@@ -4,6 +4,7 @@ pubDate: '2012-02-01T23:55:31.000Z'
 tags:
 - drupal
 - php
+description: "Tutorial para configurar xdebug y geben en emacs para debuguear PHP paso a paso, incluyendo instalación y configuración."
 title: Debuguear php con emacs, xdebug y geben
 ---
 

--- a/src/content/blog/debuguear-php-con-vim-y-xdebug.md
+++ b/src/content/blog/debuguear-php-con-vim-y-xdebug.md
@@ -4,6 +4,7 @@ pubDate: '2012-09-21T01:58:03.000Z'
 tags:
 - php
 - drupal
+description: "Configuración de vim como cliente de xdebug para debuguear PHP, comparando con NetBeans, PHPStorm y Eclipse."
 title: Debuguear PHP con vim y xdebug
 ---
 

--- a/src/content/blog/dell-vostro-1510-con-ubuntu.md
+++ b/src/content/blog/dell-vostro-1510-con-ubuntu.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2008-07-23T01:03:44.000Z'
 tags:
 - ubuntu
+description: "Experiencia instalando Ubuntu 8.04 en una laptop Dell Vostro 1510, incluyendo detección de drivers y configuración."
 title: Dell vostro 1510 con ubuntu
 ---
 

--- a/src/content/blog/demostracion-de-vim-para-edicion-rapida-de-archivos-.md
+++ b/src/content/blog/demostracion-de-vim-para-edicion-rapida-de-archivos-.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2013-03-07T21:11:22.000Z'
 tags:
 - drupal
+description: "Video demostración de comandos de VIM para edición rápida de archivos: dd, selección en bloque, macros, búsqueda y más."
 title: 'Demostración de VIM para edición rápida de archivos '
 ---
 

--- a/src/content/blog/dolores-de-cabeza-instalando-el-stack-de-microsoft.md
+++ b/src/content/blog/dolores-de-cabeza-instalando-el-stack-de-microsoft.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2009-09-22T23:33:02.000Z'
 tags: []
+description: "Experiencia instalando Visual Studio 2008 y SQL Server 2008 Express, incluyendo errores con el performance counter registry."
 title: Dolores de cabeza instalando el stack de microsoft
 ---
 

--- a/src/content/blog/drupalcamp-panama-2012.md
+++ b/src/content/blog/drupalcamp-panama-2012.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2012-09-18T00:00:00.000Z'
 tags:
 - drupal
+description: "Resumen de la DrupalCamp Panamá 2012, el evento más importante de Drupal en Centroamérica."
 title: DrupalCamp Panamá 2012
 ---
 

--- a/src/content/blog/el-brazo-robotico-de-dean-kamen.md
+++ b/src/content/blog/el-brazo-robotico-de-dean-kamen.md
@@ -3,6 +3,7 @@ aliases:
 - 2008/05/31/el-brazo-robótico-de-dean-kamen
 pubDate: '2008-05-31T17:40:33.000Z'
 tags: []
+description: "Sobre el brazo robótico desarrollado por Dean Kamen para personas amputadas y su increíble tecnología."
 title: El brazo robótico de Dean Kamen
 ---
 

--- a/src/content/blog/el-cazador.md
+++ b/src/content/blog/el-cazador.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2006-01-27T17:40:33.000Z'
 tags:
 - cuentos
+description: "Un cuento corto llamado El Cazador."
 title: El Cazador
 ---
 

--- a/src/content/blog/el-miedo-hiere-mas-que-las-espadas.md
+++ b/src/content/blog/el-miedo-hiere-mas-que-las-espadas.md
@@ -3,6 +3,7 @@ aliases:
 - el-miedo-hiere-m-s-que-las-espadas
 pubDate: '2011-08-26T18:23:01.000Z'
 tags: []
+description: "Reflexión sobre cómo el miedo puede paralizar y dañar más que cualquier arma física."
 title: El miedo hiere más que las espadas
 ---
 

--- a/src/content/blog/el-nino-robot.md
+++ b/src/content/blog/el-nino-robot.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2011-02-05T16:11:15.000Z'
 tags:
 - cuentos
+description: "Sobre el libro El niño robot y sus reflexiones sobre la relación entre humanos y tecnología."
 title: El niño robot
 ---
 

--- a/src/content/blog/el-risk-y-la-mala-suerte.md
+++ b/src/content/blog/el-risk-y-la-mala-suerte.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2011-04-26T06:30:38.000Z'
 tags: []
+description: "Reflexiones sobre el juego de mesa Risk y cómo la suerte influye en el resultado más de lo que parece."
 title: El Risk y la mala suerte
 ---
 

--- a/src/content/blog/en-bicicleta-al-trabajo.md
+++ b/src/content/blog/en-bicicleta-al-trabajo.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2008-04-21T05:17:24.000Z'
 tags:
 - bicicleta
+description: "Experiencia de ir al trabajo en bicicleta y los beneficios de esta práctica diaria."
 title: En bicicleta al trabajo
 ---
 

--- a/src/content/blog/enemigo-publico-no-1-la-iglesia-catolica.md
+++ b/src/content/blog/enemigo-publico-no-1-la-iglesia-catolica.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2012-04-12T21:22:03.000Z'
 tags:
 - religion
+description: "Reflexión crítica sobre el papel de la iglesia católica en la sociedad contemporánea."
 title: 'Enemigo público no. 1: La iglesia católica'
 ---
 

--- a/src/content/blog/enviando-mails-con-gmail-desde-la-linea-de-comandos.md
+++ b/src/content/blog/enviando-mails-con-gmail-desde-la-linea-de-comandos.md
@@ -6,6 +6,7 @@ tags:
 - ubuntu
 - consola
 - shell
+description: "Cómo configurar msmtp o sendmail para enviar correos desde la línea de comandos usando Gmail como servidor SMTP."
 title: Enviando mails con gmail desde la línea de comandos
 ---
 

--- a/src/content/blog/free-geek.md
+++ b/src/content/blog/free-geek.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2008-11-20T16:19:13.000Z'
 tags:
 - linux
+description: "Sobre Free Geek, una organización que recicla computadoras y promueve el acceso a la tecnología de forma sostenible."
 title: Free Geek
 ---
 

--- a/src/content/blog/guadalajara-devhouse-y-otros-eventos-tecnologicos-en-la-ciudad.md
+++ b/src/content/blog/guadalajara-devhouse-y-otros-eventos-tecnologicos-en-la-ciudad.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2009-09-04T19:38:51.000Z'
 tags:
 - programacion
+description: "Eventos tecnológicos en Guadalajara incluyendo DevHouse, meetups y conferencias para desarrolladores."
 title: Guadalajara DevHouse y otros eventos tecnológicos en la ciudad
 ---
 

--- a/src/content/blog/hacking-business-model.md
+++ b/src/content/blog/hacking-business-model.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2010-03-09T01:28:41.000Z'
 tags:
 - axai
+description: "Reflexiones sobre el modelo de negocio y cómo hackearlo para innovar en emprendimiento."
 title: Hacking Business Model
 ---
 

--- a/src/content/blog/historia-de-olpc.md
+++ b/src/content/blog/historia-de-olpc.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2009-01-26T18:04:08.000Z'
 tags:
 - linux
+description: "La historia del proyecto OLPC (One Laptop Per Child) y su misión de llevar computadoras a niños de países en desarrollo."
 title: Historia de OLPC
 ---
 

--- a/src/content/blog/humans-of-wizeline.md
+++ b/src/content/blog/humans-of-wizeline.md
@@ -1,4 +1,5 @@
 ---
+description: "Entrevista en la serie Humans of Wizeline sobre Joaquín Bravo y su trayectoria profesional en Wizeline."
 title: Humans of Wizeline, Joaquín Bravo
 pubDate: 'Apr 24 2023'
 heroImage: /joaquin-arbol.webp

--- a/src/content/blog/instalando-ledgersmb-en-ubuntu-1204-lts.md
+++ b/src/content/blog/instalando-ledgersmb-en-ubuntu-1204-lts.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2014-03-01T00:20:33.000Z'
 tags:
 - ubuntu
+description: "Guía para instalar LedgerSMB, un sistema de contabilidad de código abierto, en Ubuntu 12.04 LTS."
 title: Instalando LedgerSMB en ubuntu 12.04 LTS
 ---
 

--- a/src/content/blog/instalar-ubuntu-codecs-formatos-restringidos.md
+++ b/src/content/blog/instalar-ubuntu-codecs-formatos-restringidos.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2008-04-29T16:40:59.000Z'
 tags:
 - ubuntu
+description: "Cómo instalar codecs y formatos restringidos en Ubuntu para reproducir mp3, DVD y otros formatos multimedia."
 title: Instalar Ubuntu codecs (formatos restringidos)
 ---
 

--- a/src/content/blog/installing-ubuntu-codecs-restricted-formats.md
+++ b/src/content/blog/installing-ubuntu-codecs-restricted-formats.md
@@ -3,6 +3,7 @@ aliases:
 - 2008/04/29/installing-ubuntu-codecs-restricted-formats
 pubDate: '2008-04-29T15:27:25.000Z'
 tags: []
+description: "How to install restricted codecs and formats in Ubuntu to play mp3, DVDs and other multimedia formats."
 title: Installing Ubuntu codecs (restricted formats)
 ---
 

--- a/src/content/blog/las-fotos-de-uyuni.md
+++ b/src/content/blog/las-fotos-de-uyuni.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2013-02-27T16:24:39.000Z'
 tags: []
+description: "Reflexión tras perder unas fotos del Salar de Uyuni y la lección de disfrutar el momento en lugar de intentar conservarlo todo."
 title: Las fotos de Uyuni
 ---
 

--- a/src/content/blog/los-votos-de-liz-y-joaquin.md
+++ b/src/content/blog/los-votos-de-liz-y-joaquin.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2014-08-28T16:24:39.000Z'
 tags: []
+description: "Los votos matrimoniales que Liz y Joaquín escribieron para su boda, inspirados en los votos tradicionales pero personalizados."
 title: Los votos de Liz y Joaquín
 ---
 

--- a/src/content/blog/me-robaron-mi-bicicleta.md
+++ b/src/content/blog/me-robaron-mi-bicicleta.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2008-12-03T00:36:07.000Z'
 tags:
 - bicicleta
+description: "Relato sobre el robo de mi bicicleta y reflexiones sobre la confianza y los tiempos que vivimos."
 title: Me robaron mi bicicleta
 ---
 

--- a/src/content/blog/mi-accidente-en-bici.md
+++ b/src/content/blog/mi-accidente-en-bici.md
@@ -1,4 +1,5 @@
 ---
+description: "Relato del accidente en bicicleta donde me rompí el hombro durante un viaje con mis primos desde La Resolana hasta Cuastecomates."
 title: Mi accidente en bici
 pubDate: 'May 16 2023'
 heroImage: /accidente.webp

--- a/src/content/blog/migracion-a-astro.md
+++ b/src/content/blog/migracion-a-astro.md
@@ -1,4 +1,5 @@
 ---
+description: "Migración del blog personal de Gatsby a Astro con ayuda de ChatGPT, superando los problemas de complejidad de Gatsby y GraphQL."
 title: Migré mi blog de Gastby a Astro con ayuda de ChatGPT
 pubDate: 'May 11 2023'
 tags:

--- a/src/content/blog/mis-propositos-para-el-2011.md
+++ b/src/content/blog/mis-propositos-para-el-2011.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2011-01-04T16:11:39.000Z'
 tags:
 - propósitos
+description: "Lista de propósitos personales, familiares, comunitarios y profesionales para el año 2011."
 title: Mis propósitos para el 2011
 ---
 

--- a/src/content/blog/noticias-sobre-php.md
+++ b/src/content/blog/noticias-sobre-php.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2007-07-25T04:00:00.000Z'
 tags:
 - php
+description: "Noticias sobre el fin de vida de PHP 4 y la posible inclusión de namespaces en PHP 5.3 y PHP 6."
 title: noticias sobre PHP
 ---
 

--- a/src/content/blog/noticias-sobre-php5.md
+++ b/src/content/blog/noticias-sobre-php5.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2007-07-26T02:30:00.000Z'
 tags:
 - php
+description: "Noticias sobre el fin de soporte de PHP 4 y la llegada de namespaces a PHP 5.3 y PHP 6."
 title: Noticias sobre PHP5
 ---
 

--- a/src/content/blog/omitir-archivos-de-svn-al-buscar-con-grep.md
+++ b/src/content/blog/omitir-archivos-de-svn-al-buscar-con-grep.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2008-10-29T17:32:32.000Z'
 tags:
 - linux
+description: "Cómo configurar grep para excluir archivos de subversion (.svn) al buscar en proyectos usando GREP_OPTIONS en .bashrc."
 title: Omitir archivos de svn al buscar con grep
 ---
 

--- a/src/content/blog/propositos-2017.md
+++ b/src/content/blog/propositos-2017.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2017-02-04T16:11:39.000Z'
 tags:
 - propósitos
+description: "Lista de propósitos para el año 2017: salir temprano, ejercicio, viajes familiares, meditación y correr con las perritas."
 title: Mis propósitos para el 2017
 ---
 

--- a/src/content/blog/propositos-2020.md
+++ b/src/content/blog/propositos-2020.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2020-01-10T16:11:39.000Z'
 tags:
 - propósitos
+description: "Propósitos para el 2020: balance trabajo-vida, ejercicio, viajes, contribuciones open source y conferencias de software."
 title: Mis propósitos para el 2020
 ---
 

--- a/src/content/blog/que-buenos-eran-los-muppets.md
+++ b/src/content/blog/que-buenos-eran-los-muppets.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2011-01-21T15:11:27.000Z'
 tags: []
+description: "Homenaje a los Muppets con un par de videos clásicos que demuestran lo geniales que eran."
 title: Que buenos eran los Muppets!
 ---
 

--- a/src/content/blog/que-es-eso-del-technorati-blog-claim.md
+++ b/src/content/blog/que-es-eso-del-technorati-blog-claim.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2008-02-07T16:30:22.000Z'
 tags:
 - blogs
+description: "Explicación de qué es Technorati, cómo registrar tu blog y por qué es importante para ganar visibilidad y autoridad."
 title: ¿Que es eso del technorati blog claim?
 ---
 

--- a/src/content/blog/que-preferencia-sexual-quisieras-que-tuvieran-tus-hijos.md
+++ b/src/content/blog/que-preferencia-sexual-quisieras-que-tuvieran-tus-hijos.md
@@ -4,6 +4,7 @@ aliases:
 pubDate: '2010-05-20T14:00:16.000Z'
 tags:
 - religion
+description: "Reflexión sobre la homofobia, los prejuicios sobre la crianza en familias homosexuales y la importancia de respetar y amar a todas las personas."
 title: ¿Qué preferencia sexual quisieras que tuvieran tus hijos?
 ---
 

--- a/src/content/blog/redirigir-los-dominios-www-usando-aegir-y-nginx.md
+++ b/src/content/blog/redirigir-los-dominios-www-usando-aegir-y-nginx.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2010-11-19T23:21:01.000Z'
 tags:
 - drupal
+description: "Cómo configurar una regla de nginx para redirigir todos los dominios con www al dominio sin www usando Aegir."
 title: redirigir los dominios www usando aegir y nginx
 ---
 

--- a/src/content/blog/rehabilitacion-post-accidente.md
+++ b/src/content/blog/rehabilitacion-post-accidente.md
@@ -1,4 +1,5 @@
 ---
+description: "Recuperación y rehabilitación tras el accidente en bici donde me rompí el hombro, dividida en tres periodos de recuperación."
 title: Rehabilitación post accidente
 pubDate: 'Feb 27 2024'
 heroImage: /acostado.webp

--- a/src/content/blog/se-busca-programador.md
+++ b/src/content/blog/se-busca-programador.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2009-09-08T15:50:18.000Z'
 tags:
 - axai
+description: "Axai busca programadores web apasionados con experiencia en Drupal y Symfony para unirse al equipo de desarrollo."
 title: Se busca programador
 ---
 

--- a/src/content/blog/setup-de-ambiente-de-desarrollo-ubuntu-debian.md
+++ b/src/content/blog/setup-de-ambiente-de-desarrollo-ubuntu-debian.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2014-05-06T18:41:41.000Z'
 tags: []
+description: "Guía para configurar un ambiente de desarrollo Drupal en Ubuntu/Debian con nginx, MySQL, PHP y git."
 title: Setup de ambiente de desarrollo (ubuntu / debian)
 ---
 

--- a/src/content/blog/sobre-democracia-20-y-el-wikipartido.md
+++ b/src/content/blog/sobre-democracia-20-y-el-wikipartido.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2013-03-07T00:21:45.000Z'
 tags: []
+description: "Reflexiones sobre Democracia 2.0 y el wikipartido, iniciativas para crear plataformas tecnológicas democráticas para nuevos partidos políticos en México."
 title: Sobre Democracia 2.0 y el wikipartido
 ---
 

--- a/src/content/blog/sobre-la-fe.md
+++ b/src/content/blog/sobre-la-fe.md
@@ -3,6 +3,7 @@ aliases: []
 pubDate: '2013-01-27T06:17:08.000Z'
 tags:
 - religion
+description: "Reflexión sobre la fe como confianza basada en la experiencia, no como creencia ciega, y la importancia de cuestionar y probar las propias creencias."
 title: Sobre la fe
 ---
 

--- a/src/content/blog/suki.md
+++ b/src/content/blog/suki.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2017-02-21T19:54:43.000Z'
 tags: []
+description: "Homenaje a Suki, una perrita intensa, cariñosa y llena de energía que fue parte de la familia y se fue demasiado pronto."
 title: Suki
 ---
 

--- a/src/content/blog/un-retorno-a-hattrick.md
+++ b/src/content/blog/un-retorno-a-hattrick.md
@@ -4,6 +4,7 @@ aliases:
 - un-retorno-hattrick
 pubDate: '2010-05-22T14:12:58.000Z'
 tags: []
+description: "Un mensaje nostálgico del antiguo capitán del equipo en Hattrick que motiva a regresar al juego de gestión de fútbol."
 title: Un retorno a Hattrick
 ---
 

--- a/src/content/blog/una-aventura-extraordinaria-life-of-pi.md
+++ b/src/content/blog/una-aventura-extraordinaria-life-of-pi.md
@@ -3,6 +3,7 @@ aliases:
 - una-aventura-extraordinaria-life-pi
 pubDate: '2013-03-12T15:50:33.000Z'
 tags: []
+description: "Reflexión sobre la película Life of Pi, la tolerancia religiosa y cómo la religión es una interpretación de la vida."
 title: Una aventura extraordinaria (Life of Pi)
 ---
 

--- a/src/content/blog/url-shorteners-y-estadisticas-de-visitas.md
+++ b/src/content/blog/url-shorteners-y-estadisticas-de-visitas.md
@@ -2,6 +2,7 @@
 aliases: []
 pubDate: '2009-09-23T19:06:38.000Z'
 tags: []
+description: "Cómo usar bit.ly y otros acortadores de URL para rastrear estadísticas de visitas en los enlaces compartidos en Twitter."
 title: URL shorteners y estadísticas de visitas
 ---
 

--- a/src/content/blog/usando-la-consola-cuanto-miden-tus-particiones-y-carpetas.md
+++ b/src/content/blog/usando-la-consola-cuanto-miden-tus-particiones-y-carpetas.md
@@ -6,6 +6,7 @@ tags:
 - ubuntu
 - consola
 - shell
+description: "Comandos df y du en Linux para verificar el tamaño de particiones y carpetas desde la línea de comandos."
 title: 'Usando la consola: Cuanto miden tus particiones y carpetas?'
 ---
 

--- a/src/content/blog/usando-tags-de-taxonomia-para-organizar-el-contenido-en-drupal.md
+++ b/src/content/blog/usando-tags-de-taxonomia-para-organizar-el-contenido-en-drupal.md
@@ -5,6 +5,7 @@ pubDate: '2008-08-26T19:26:34.000Z'
 tags:
 - drupal
 - axai
+description: "Cómo usar tags de taxonomía en Drupal para organizar contenido de manera consistente y mejorar el SEO del sitio."
 title: Usando tags de taxonomía para organizar el contenido en drupal
 ---
 

--- a/src/content/blog/usando-views-handlers-para-mostrar-el-total-de-una-vista-de-inventario.md
+++ b/src/content/blog/usando-views-handlers-para-mostrar-el-total-de-una-vista-de-inventario.md
@@ -5,6 +5,7 @@ pubDate: '2011-08-04T16:35:24.000Z'
 tags:
 - drupal
 - views
+description: "Cómo implementar un views handler personalizado en Drupal 7 para mostrar totales en vistas de inventario."
 title: Usando views handlers para mostrar el total de una vista de inventario
 ---
 

--- a/src/content/blog/usando-wget-para-bajar-canciones-o-imagenes.md
+++ b/src/content/blog/usando-wget-para-bajar-canciones-o-imagenes.md
@@ -4,6 +4,7 @@ pubDate: '2008-12-05T20:24:08.000Z'
 tags:
 - linux
 - consola
+description: "Cómo usar wget para descargar imágenes y archivos de un servidor web de forma recursiva y automatizada en Linux."
 title: Usando wget para bajar canciones o imágenes
 ---
 


### PR DESCRIPTION
## Problem

All 59 blog posts were missing the `description` frontmatter field. The BlogPost layout falls back to an empty string for the `<meta name="description">` tag when no description is provided. This hurts SEO for every single blog post.

## Solution

Added a concise Spanish `description` field to every blog post's frontmatter. Each description summarizes the post content in 1-2 sentences, optimized for search engine snippets.

## Changes

- Added `description` frontmatter to all 59 blog posts in `src/content/blog/`
- Descriptions are in Spanish (matching the content language)
- Each description is a unique summary of the post's topic

## Example

Before:
```yaml
---
pubDate: '2008-08-05T16:26:48.000Z'
tags:
- git
- mysql
title: Backups de MySQL con git
---
```

After:
```yaml
---
pubDate: '2008-08-05T16:26:48.000Z'
tags:
- git
- mysql
description: "Cómo hacer backups de bases de datos MySQL utilizando git como sistema de control de versiones, aprovechando la opción --tab de mysqldump para rastrear cambios históricos."
title: Backups de MySQL con git
---
```

Fixes issue #5