### PR TITLE
fix: Unique titles and descriptions for tag pages

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -2,7 +2,7 @@
 import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
-import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
+import { SITE_TITLE } from '../../consts';
 import FormattedDate from '../../components/FormattedDate.astro';
 import { getCollection } from 'astro:content';
 
@@ -24,11 +24,13 @@ export async function getStaticPaths() {
 
 const { tag } = Astro.params;
 const { posts } = Astro.props;
+const pageTitle = `Posts tagged '${tag}' - ${SITE_TITLE}`;
+const pageDescription = `Lista de posts etiquetados con '${tag}' en ${SITE_TITLE}`;
 ---
 <!DOCTYPE html>
 <html lang="es">
 	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+		<BaseHead title={pageTitle} description={pageDescription} />
 		<style>
 			ul {
 				list-style-type: none;

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -2,7 +2,7 @@
 import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
-import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
+import { SITE_TITLE } from '../../consts';
 import { getCollection } from 'astro:content';
 
 const posts = (await getCollection('blog'));
@@ -11,12 +11,15 @@ const tagsAndCounts = uniqueTags.map((tag) => {
     const count = posts.filter((post) => post.data.tags?.includes(tag || "none")).length;
 	return { count, tag }
 })
+
+const pageTitle = `Tags - ${SITE_TITLE}`;
+const pageDescription = `Lista de todos los tags usados en ${SITE_TITLE}`;
 ---
 
 <!DOCTYPE html>
 <html lang="es">
 	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+		<BaseHead title={pageTitle} description={pageDescription} />
 		<style>
 			ul {
 				list-style-type: none;


### PR DESCRIPTION
## Problem

All tag pages (`/tags/git`, `/tags/drupal`, etc.) and the `/tags` index shared the exact same `<title>` and `<meta description>` as the homepage: `"La gaceta de la cabeza"`. Search engines see these as duplicate pages.

## Solution

Each page now generates a unique, descriptive title and description:

| Page | Before | After |
|------|--------|-------|
| `/tags` | `La gaceta de la cabeza` | `Tags - La gaceta de la cabeza` |
| `/tags/git` | `La gaceta de la cabeza` | `Posts tagged 'git' - La gaceta de la cabeza` |
| `/tags/drupal` | `La gaceta de la cabeza` | `Posts tagged 'drupal' - La gaceta de la cabeza` |

## Changes

- **`src/pages/tags/[tag].astro`** — dynamic title: `Posts tagged '{tag}' - {SITE_TITLE}`, description: `Lista de posts etiquetados con '{tag}' en {SITE_TITLE}`
- **`src/pages/tags/index.astro`** — title: `Tags - {SITE_TITLE}`, description: `Lista de todos los tags usados en {SITE_TITLE}`

Fixes issue #6