### PR TITLE
Add robots.txt with sitemap reference

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://jackbravo.github.io/sitemap-index.xml


### PR DESCRIPTION
## What

Adds a `robots.txt` file to the `public/` directory.

## Details

- Allows all crawlers access to the site (`User-agent: * Allow: /`)
- References the sitemap generated by `@astrojs/sitemap` at `https://jackbravo.github.io/sitemap-index.xml`

The sitemap integration is already configured in `astro.config.mjs` — this PR just adds the `robots.txt` so search engine crawlers can discover it.